### PR TITLE
Delete account command

### DIFF
--- a/src/backend/blockchain-endpoints.ts
+++ b/src/backend/blockchain-endpoints.ts
@@ -18,7 +18,9 @@ export const ExtendExpirationParamsSchema = z.object({
 export const ExtendExpirationResponseSchema = ExtendExpirationCoreCommandParamsSchema;
 
 export const InitializeAccountParamsSchema = z.object({
-  username: z.string(),
+  username: z.string().refine(data => data.toLocaleLowerCase() !== "deleted", {
+    message: "Username cannot be 'deleted'",
+  }),
   email: EmailSchema,
   type: AccountTypeSchema,
   companyDetails: CompanyDetailsSchema,

--- a/src/core/core-commands-types.ts
+++ b/src/core/core-commands-types.ts
@@ -5,6 +5,7 @@ import {
   CreateCollectionCoreCommandParamsSchema,
   CreateFileCoreCommandParamsSchema,
   CreateNetworkCoreCommandParamsSchema,
+  DeleteAccountCoreCommandParamsSchema,
   ExtendExpirationCoreCommandParamsSchema,
   InitializeAccountCoreCommandParamsSchema,
   RequestCollectionAccessCoreCommandParamsSchema,
@@ -29,6 +30,7 @@ export enum Command {
   CreateCollection = "createCollection",
   CreateFile = "createFile",
   CreateNetwork = "createNetwork",
+  DeleteAccount = "deleteAccount",
   ExtendExpiration = "extendExpiration",
   InitializeAccount = "initializeAccount",
   RequestCollectionAccess = "requestCollectionAccess",
@@ -56,6 +58,8 @@ export type CreateCollectionCoreCommandParams = z.infer<
 export type CreateFileCoreCommandParams = z.infer<typeof CreateFileCoreCommandParamsSchema>;
 
 export type CreateNetworkCoreCommandParams = z.infer<typeof CreateNetworkCoreCommandParamsSchema>;
+
+export type DeleteAccountCoreCommandParams = z.infer<typeof DeleteAccountCoreCommandParamsSchema>;
 
 export type ExtendExpirationCoreCommandParams = z.infer<
   typeof ExtendExpirationCoreCommandParamsSchema

--- a/src/core/core-commands.ts
+++ b/src/core/core-commands.ts
@@ -54,6 +54,10 @@ export const CreateNetworkCoreCommandParamsSchema = NetworkSchema.omit({
   timestamp: TimestampSchema,
 });
 
+export const DeleteAccountCoreCommandParamsSchema = z.object({
+  timestamp: TimestampSchema,
+});
+
 export const ExtendExpirationCoreCommandParamsSchema = z.object({
   fileIds: z.array(z.string()),
   amount: z.number(),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -112,6 +112,8 @@ import {
   SetReadStatusActionResponseSchema,
   CommandSchema,
   ActionSchema,
+  DeleteAccountCoreCommandParamsSchema,
+  DeleteAccountCoreCommandParams,
 } from "./core";
 
 export const commandRequestSchemas: { [key in Command]: ZodSchema } = {
@@ -119,6 +121,7 @@ export const commandRequestSchemas: { [key in Command]: ZodSchema } = {
   [Command.CreateCollection]: CreateCollectionCoreCommandParamsSchema,
   [Command.CreateFile]: CreateFileCoreCommandParamsSchema,
   [Command.CreateNetwork]: CreateNetworkCoreCommandParamsSchema,
+  [Command.DeleteAccount]: DeleteAccountCoreCommandParamsSchema,
   [Command.ExtendExpiration]: ExtendExpirationCoreCommandParamsSchema,
   [Command.InitializeAccount]: InitializeAccountCoreCommandParamsSchema,
   [Command.RequestCollectionAccess]: RequestCollectionAccessCoreCommandParamsSchema,
@@ -142,6 +145,7 @@ export type CommandParams =
   | { command: Command.CreateCollection; params: CreateCollectionCoreCommandParams }
   | { command: Command.CreateFile; params: CreateFileCoreCommandParams }
   | { command: Command.CreateNetwork; params: CreateNetworkCoreCommandParams }
+  | { command: Command.DeleteAccount; params: DeleteAccountCoreCommandParams }
   | { command: Command.ExtendExpiration; params: ExtendExpirationCoreCommandParams }
   | { command: Command.InitializeAccount; params: InitializeAccountCoreCommandParams }
   | { command: Command.RequestCollectionAccess; params: RequestCollectionAccessCoreCommandParams }


### PR DESCRIPTION
This pull request includes changes to add a new command for deleting accounts and to refine the username validation in account initialization. The most important changes include adding the `DeleteAccount` command and its associated schema, and updating the username validation to disallow the username "deleted".

### New Command for Deleting Accounts:

* [`src/core/core-commands-types.ts`](diffhunk://#diff-b9f545f633b3a651ede10802a0bcf260e909f2b041ae0c8dc6d8598c6890e3c8R8): Added `DeleteAccountCoreCommandParamsSchema` to the list of imports and added the `DeleteAccount` command to the `Command` enum. Defined the type `DeleteAccountCoreCommandParams` using the new schema. [[1]](diffhunk://#diff-b9f545f633b3a651ede10802a0bcf260e909f2b041ae0c8dc6d8598c6890e3c8R8) [[2]](diffhunk://#diff-b9f545f633b3a651ede10802a0bcf260e909f2b041ae0c8dc6d8598c6890e3c8R33) [[3]](diffhunk://#diff-b9f545f633b3a651ede10802a0bcf260e909f2b041ae0c8dc6d8598c6890e3c8R62-R63)
* [`src/core/core-commands.ts`](diffhunk://#diff-be80bcb6fd50e6f48de34468bd8b8338da38026e5b3f9c097d2b67575c778ae8R57-R60): Defined `DeleteAccountCoreCommandParamsSchema` with a `timestamp` field.
* [`src/helpers.ts`](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R115-R124): Added `DeleteAccountCoreCommandParamsSchema` and `DeleteAccountCoreCommandParams` to the list of imports. Updated the `commandRequestSchemas` and `CommandParams` to include the new `DeleteAccount` command. [[1]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R115-R124) [[2]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R148)

### Username Validation:

* [`src/backend/blockchain-endpoints.ts`](diffhunk://#diff-e51c64e51caf9e5be9ca574ec85088ba24d5dec052ebbf25d4f5b6d9d9ea3597L21-R23): Updated the `InitializeAccountParamsSchema` to refine the `username` field, disallowing the username "deleted".