### PR TITLE
Add Backend Admin Panel schemas

### DIFF
--- a/src/backend/backend-endpoints-types.ts
+++ b/src/backend/backend-endpoints-types.ts
@@ -1,0 +1,27 @@
+import z from "zod";
+
+import {
+  GetCustomClientResponseSchema,
+  GetCustomClientsResponseSchema,
+  GetSystemInfoResponseSchema,
+  PostCustomClientRequestSchema,
+  PostCustomClientResponseSchema,
+  PostLoginRequestSchema,
+  PostLoginResponseSchema,
+} from "./backend-endpoints";
+
+export type GetSystemInfoResponse = z.infer<typeof GetSystemInfoResponseSchema>;
+
+export type PostLoginRequest = z.infer<typeof PostLoginRequestSchema>;
+
+export type PostLoginResponse = z.infer<typeof PostLoginResponseSchema>;
+
+export type CustomClient = z.infer<typeof PostCustomClientRequestSchema>;
+
+export type PostCustomClientRequest = z.infer<typeof PostCustomClientRequestSchema>;
+
+export type PostCustomClientResponse = z.infer<typeof PostCustomClientResponseSchema>;
+
+export type GetCustomClientResponse = z.infer<typeof GetCustomClientResponseSchema>;
+
+export type GetCustomClientsResponse = z.infer<typeof GetCustomClientsResponseSchema>;

--- a/src/backend/backend-endpoints-types.ts
+++ b/src/backend/backend-endpoints-types.ts
@@ -1,6 +1,8 @@
 import z from "zod";
 
 import {
+  DeleteCustomClientRequestSchema,
+  DeleteCustomClientResponseSchema,
   GetCustomClientResponseSchema,
   GetCustomClientsResponseSchema,
   GetSystemInfoResponseSchema,
@@ -8,6 +10,10 @@ import {
   PostCustomClientResponseSchema,
   PostLoginRequestSchema,
   PostLoginResponseSchema,
+  PostTestEmailRequestSchema,
+  PostTestEmailResponseSchema,
+  UpdateCustomClientRequestSchema,
+  UpdateCustomClientResponseSchema,
 } from "./backend-endpoints";
 
 export type GetSystemInfoResponse = z.infer<typeof GetSystemInfoResponseSchema>;
@@ -25,3 +31,15 @@ export type PostCustomClientResponse = z.infer<typeof PostCustomClientResponseSc
 export type GetCustomClientResponse = z.infer<typeof GetCustomClientResponseSchema>;
 
 export type GetCustomClientsResponse = z.infer<typeof GetCustomClientsResponseSchema>;
+
+export type UpdateCustomClientRequest = z.infer<typeof UpdateCustomClientRequestSchema>;
+
+export type UpdateCustomClientResponse = z.infer<typeof UpdateCustomClientResponseSchema>;
+
+export type DeleteCustomClientRequest = z.infer<typeof DeleteCustomClientRequestSchema>;
+
+export type DeleteCustomClientResponse = z.infer<typeof DeleteCustomClientResponseSchema>;
+
+export type PostTestEmailRequest = z.infer<typeof PostTestEmailRequestSchema>;
+
+export type PostTestEmailResponse = z.infer<typeof PostTestEmailResponseSchema>;

--- a/src/backend/backend-endpoints.ts
+++ b/src/backend/backend-endpoints.ts
@@ -1,0 +1,44 @@
+import z from "zod";
+import { htmlColorInputSchema } from "../shared/generic";
+
+export const GetSystemInfoResponseSchema = z.object({
+  systemUptime: z.number(),
+  cpuUsage: z.number(),
+  memActive: z.number(),
+  memTotal: z.number(),
+  totalDiskUsed: z.number(),
+  totalDiskSize: z.number(),
+});
+
+export const PostLoginRequestSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});
+
+export const PostLoginResponseSchema = z.object({
+  token: z.string(),
+});
+
+export const CustomClientSchema = z.object({
+  clientName: z.string(),
+  networkLabel: z.string(),
+  url: z.string().url(),
+  filePageUrl: z
+    .string()
+    .url()
+    .refine(value => /\{\{fileId\}\}/.test(value ?? ""), "URL must contain {{fileId}}"),
+  landingPageUrl: z.string().url(),
+  logoUrl: z.string().url(),
+  sendGridApiKey: z.string(),
+  sendGridSender: z.string().email(),
+  primaryColor: htmlColorInputSchema,
+  secondaryColor: htmlColorInputSchema,
+});
+
+export const PostCustomClientRequestSchema = CustomClientSchema;
+
+export const PostCustomClientResponseSchema = z.null();
+
+export const GetCustomClientResponseSchema = CustomClientSchema;
+
+export const GetCustomClientsResponseSchema = z.array(CustomClientSchema);

--- a/src/backend/backend-endpoints.ts
+++ b/src/backend/backend-endpoints.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+
 import { htmlColorInputSchema } from "../shared/generic";
 
 export const GetSystemInfoResponseSchema = z.object({
@@ -42,3 +43,19 @@ export const PostCustomClientResponseSchema = z.null();
 export const GetCustomClientResponseSchema = CustomClientSchema;
 
 export const GetCustomClientsResponseSchema = z.array(CustomClientSchema);
+
+export const UpdateCustomClientRequestSchema = CustomClientSchema;
+
+export const UpdateCustomClientResponseSchema = z.null();
+
+export const DeleteCustomClientRequestSchema = z.object({
+  networkLabel: z.string(),
+});
+
+export const DeleteCustomClientResponseSchema = z.null();
+
+export const PostTestEmailRequestSchema = CustomClientSchema.extend({
+  recipientEmail: z.string().email(),
+});
+
+export const PostTestEmailResponseSchema = z.null();

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,3 +1,5 @@
+export * from "./backend-endpoints";
+export * from "./backend-endpoints-types";
 export * from "./blockchain-endpoints";
 export * from "./blockchain-endpoints-types";
 export * from "./dam-endpoints";

--- a/src/core/core-actions-types.ts
+++ b/src/core/core-actions-types.ts
@@ -30,6 +30,8 @@ import {
   GetFilesActionResponseSchema,
   GetFilesByIdsActionParamsSchema,
   GetFilesByIdsActionResponseSchema,
+  GetNetworksActionParamsSchema,
+  GetNetworksActionResponseSchema,
   GetNotificationDataActionParamsSchema,
   GetNotificationDataActionResponseSchema,
   GetStorageStatisticsActionParamsSchema,
@@ -58,6 +60,7 @@ export enum Action {
   AccountIsInitialized = "storage_accountIsInitialized",
   AccountIsTaken = "storage_accountIsTaken",
   GetAccount = "storage_getAccount",
+  GetNetworks = "api_getNetworks",
 }
 
 export type Filters = z.infer<typeof FiltersSchema>;
@@ -156,3 +159,7 @@ export type AccountIsInitializedActionResponse = z.infer<
 export type AccountIsTakenActionResponse = z.infer<typeof AccountIsTakenActionResponseSchema>;
 
 export type GetAccountActionResponse = z.infer<typeof GetAccountActionResponseSchema>;
+
+export type GetNetworksActionResponse = z.infer<typeof GetNetworksActionResponseSchema>;
+
+export type GetNetworksActionParams = z.infer<typeof GetNetworksActionParamsSchema>;

--- a/src/core/core-actions.ts
+++ b/src/core/core-actions.ts
@@ -125,3 +125,9 @@ export const AccountIsInitializedActionResponseSchema = z.boolean();
 export const AccountIsTakenActionResponseSchema = z.boolean();
 
 export const GetAccountActionResponseSchema = z.union([AccountPropsSchema, z.null()]);
+
+export const GetNetworksActionParamsSchema = z.null();
+
+export const GetNetworksActionResponseSchema = getSanitizedListResponseSchema(
+  NetworkSchema.array()
+);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -114,6 +114,9 @@ import {
   ActionSchema,
   DeleteAccountCoreCommandParamsSchema,
   DeleteAccountCoreCommandParams,
+  GetNetworksActionParamsSchema,
+  GetNetworksActionResponseSchema,
+  GetNetworksActionParams,
 } from "./core";
 
 export const commandRequestSchemas: { [key in Command]: ZodSchema } = {
@@ -198,6 +201,7 @@ export const actionRequestSchemas: { [key in Action]: ZodSchema } = {
   [Action.AccountIsInitialized]: AccountIsInitializedActionParamsSchema,
   [Action.AccountIsTaken]: AccountIsTakenActionParamsSchema,
   [Action.GetAccount]: GetAccountActionParamsSchema,
+  [Action.GetNetworks]: GetNetworksActionParamsSchema,
 };
 
 export type ActionParams =
@@ -220,7 +224,8 @@ export type ActionParams =
   | { action: Action.SetReadAllStatus; params: SetReadAllStatusActionParams }
   | { action: Action.AccountIsInitialized; params: AccountIsInitializedActionParams }
   | { action: Action.AccountIsTaken; params: AccountIsTakenActionParams }
-  | { action: Action.GetAccount; params: GetAccountActionParams };
+  | { action: Action.GetAccount; params: GetAccountActionParams }
+  | { action: Action.GetNetworks; params: GetNetworksActionParams };
 
 export const ActionRequestSchema = z.object({
   action: ActionSchema,
@@ -247,6 +252,7 @@ export const ActionResponseSchemas: { [key in Action]: ZodSchema } = {
   [Action.AccountIsInitialized]: AccountIsInitializedActionResponseSchema,
   [Action.AccountIsTaken]: AccountIsTakenActionResponseSchema,
   [Action.GetAccount]: GetAccountActionResponseSchema,
+  [Action.GetNetworks]: GetNetworksActionResponseSchema,
 };
 
 export type ActionResponse =

--- a/src/shared/generic-types.ts
+++ b/src/shared/generic-types.ts
@@ -1,6 +1,8 @@
 import z from "zod";
-import { FormDataBooleanSchema, PassphraseSchema } from "./generic";
+import { FormDataBooleanSchema, htmlColorInputSchema, PassphraseSchema } from "./generic";
 
 export type Passphrase = z.infer<typeof PassphraseSchema>;
 
 export type FormDataBoolean = z.infer<typeof FormDataBooleanSchema>;
+
+export type HtmlColorInput = z.infer<typeof htmlColorInputSchema>;

--- a/src/shared/generic.ts
+++ b/src/shared/generic.ts
@@ -15,3 +15,9 @@ export const FormDataBooleanSchema = z.preprocess(
 export const BigIntSchema = z.coerce.bigint();
 
 export const SanitizedString = z.string().trim().max(64);
+
+export const htmlColorInputSchema = z
+  .string()
+  .regex(/^#[0-9a-fA-F]{6}$/, {
+    message: "Invalid color format. Must be a 7-character hex code (e.g., #RRGGBB).",
+  });


### PR DESCRIPTION
This pull request introduces new backend endpoint schemas for custom client management and system information, adds support for a "GetNetworks" action in the core logic, and improves type safety around HTML color inputs. The changes focus on expanding API capabilities and ensuring strict data validation.

**Backend endpoint schemas and types:**

* Added new schemas and types for custom client management and system info endpoints, including request and response validation using `zod` in `backend-endpoints.ts` and `backend-endpoints-types.ts`. [[1]](diffhunk://#diff-00c528c9a1396add42e6fd90d63c7cc05ef77eca2e7030cb96725db2716d6276R1-R61) [[2]](diffhunk://#diff-a79ca0d7d5daf469228dc9500729e59797c873312e0f72666e55c27bf5a27fdfR1-R45)
* Re-exported backend endpoint modules in `index.ts` for easier access.

**Core actions and helpers:**

* Introduced the `GetNetworks` action, including its params and response schemas, and integrated it into the core actions and helpers for request/response validation and type safety. [[1]](diffhunk://#diff-0ca82b8c5954dd7ef63e6763ebab97d71c91ebc2a341fef9b93d418a1c3185d2R33-R34) [[2]](diffhunk://#diff-0ca82b8c5954dd7ef63e6763ebab97d71c91ebc2a341fef9b93d418a1c3185d2R63) [[3]](diffhunk://#diff-0ca82b8c5954dd7ef63e6763ebab97d71c91ebc2a341fef9b93d418a1c3185d2R162-R165) [[4]](diffhunk://#diff-9526f39ef841f3874a3a8740c561f4cc52bc469c0f2208ccd683e76f2bbba3aaR128-R133) [[5]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R117-R119) [[6]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R204) [[7]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99L223-R228) [[8]](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R255)

**Shared types and validation:**

* Added `htmlColorInputSchema` for validating hex color strings and exposed its type as `HtmlColorInput` for use in API schemas. [[1]](diffhunk://#diff-dd5d7d558548056b3cfa74efeab1142a4ee0a226a370bda418eb60ec16d8fb05R18-R23) [[2]](diffhunk://#diff-e37702050c56bba171b5e087a8d0bf0de17744b0a056c855fe455c4205655dfeL2-R8)