### PR TITLE
Use named imports

### DIFF
--- a/src/backend/backend-endpoints-types.ts
+++ b/src/backend/backend-endpoints-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   DeleteCustomClientRequestSchema,

--- a/src/backend/backend-endpoints.ts
+++ b/src/backend/backend-endpoints.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import { htmlColorInputSchema } from "../shared/generic";
 

--- a/src/backend/blockchain-endpoints-types.ts
+++ b/src/backend/blockchain-endpoints-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   ExtendExpirationParamsSchema,

--- a/src/backend/blockchain-endpoints.ts
+++ b/src/backend/blockchain-endpoints.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   AccountTypeSchema,

--- a/src/backend/dam-endpoints-types.ts
+++ b/src/backend/dam-endpoints-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import {
   DownloadFileParamsSchema,
   DownloadFileResponseSchema,

--- a/src/backend/dam-endpoints.ts
+++ b/src/backend/dam-endpoints.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { zfd } from "zod-form-data";
 
 import {

--- a/src/backend/stripe-endpoints-types.ts
+++ b/src/backend/stripe-endpoints-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { CreateCheckoutSessionParamsSchema, StripeProductSchema } from "./stripe-endpoints";
 
 export type CreateCheckoutSessionParams = z.infer<typeof CreateCheckoutSessionParamsSchema>;

--- a/src/backend/stripe-endpoints.ts
+++ b/src/backend/stripe-endpoints.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { EmailSchema } from "../core";
 
 export const CreateCheckoutSessionParamsSchema = z.object({

--- a/src/core/core-actions-types.ts
+++ b/src/core/core-actions-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   AccountIsInitializedActionParamsSchema,

--- a/src/core/core-actions.ts
+++ b/src/core/core-actions.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { NotificationItemSchema, NotificationTypeSchema } from "../notification-plugin";
 import { CollectionSchema, DamFileSchema, NetworkSchema } from "./core-generic";
 import { AccountPropsSchema, MapStoreDataSchema, StatisticStoreDataSchema } from "./core-stores";

--- a/src/core/core-stores-types.ts
+++ b/src/core/core-stores-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   AccountPropsSchema,

--- a/src/core/core-stores.ts
+++ b/src/core/core-stores.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   AccountTypeSchema,

--- a/src/notification-plugin/plugin-generic-types.ts
+++ b/src/notification-plugin/plugin-generic-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 import {
   FileExpirationStoreDataSchema,

--- a/src/shared/generic-types.ts
+++ b/src/shared/generic-types.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { FormDataBooleanSchema, htmlColorInputSchema, PassphraseSchema } from "./generic";
 
 export type Passphrase = z.infer<typeof PassphraseSchema>;

--- a/src/shared/generic.ts
+++ b/src/shared/generic.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 export const PassphraseSchema = z.string();
 
@@ -16,8 +16,6 @@ export const BigIntSchema = z.coerce.bigint();
 
 export const SanitizedString = z.string().trim().max(64);
 
-export const htmlColorInputSchema = z
-  .string()
-  .regex(/^#[0-9a-fA-F]{6}$/, {
-    message: "Invalid color format. Must be a 7-character hex code (e.g., #RRGGBB).",
-  });
+export const htmlColorInputSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, {
+  message: "Invalid color format. Must be a 7-character hex code (e.g., #RRGGBB).",
+});


### PR DESCRIPTION
This PR refactors the way zod is imported throughout the project. Instead of sometimes using a default import, named imports are now always used.